### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,12 +359,12 @@
       </releases>
       <snapshots />
       <id>Codehaus Snapshots</id>
-      <url>http://nexus.codehaus.org/snapshots</url>
+      <url>https://nexus.codehaus.org/snapshots</url>
     </repository>
     <repository>
       <id>logging.rc</id>
       <name>logging services release candidates</name>
-      <url>http://people.apache.org/builds/logging/repo</url>
+      <url>https://people.apache.org/builds/logging/repo</url>
     </repository>
   </repositories>
   <pluginRepositories>
@@ -374,7 +374,7 @@
       </releases>
       <snapshots />
       <id>Codehaus Snapshots</id>
-      <url>http://nexus.codehaus.org/snapshots</url>
+      <url>https://nexus.codehaus.org/snapshots</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>


### PR DESCRIPTION
{"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A pull request already exists for JLLeitschuh:fix/JLL/use_https_to_resolve_dependencies_maven."}],"documentation_url":"https://docs.github.com/rest/reference/pulls#create-a-pull-request"}